### PR TITLE
Minor guide updates

### DIFF
--- a/practitioner-guides/responsiveness.md
+++ b/practitioner-guides/responsiveness.md
@@ -99,6 +99,7 @@ Responsiveness can be a challenging metric to improve because many things happen
 # Additional Reading
 
 * The [Contributor Sustainability Practitioner Guide](https://chaoss.community/practitioner-guide-contributor-sustainability/) has more details about recruiting contributors and moving them into leadership roles, like reviewer and maintainer.
+* [CHAOSScast episode about this responsiveness guide](https://podcast.chaoss.community/85)
 * [Measuring Open Source project health](https://opensource.net/measure-open-source-project-health/) has a section about responsiveness.
 * [Anatomy of a Perfect Pull Request](https://opensource.com/article/18/6/anatomy-perfect-pull-request) for more ideas about guidance you might give to help people make better contributions that are easier for maintainers to review.
 

--- a/practitioner-guides/website-landing.md
+++ b/practitioner-guides/website-landing.md
@@ -5,8 +5,8 @@ These guides will be especially useful for Open Source Program Offices (OSPOs), 
 **Guides**
 
 * [Practitioner Guide: Introduction - Things to Think about When Interpreting Metrics](https://chaoss.community/practitioner-guide-introduction/) <- Please start here
-* [Practitioner Guide: Responsiveness](https://chaoss.community/practitioner-guide-responsiveness/)
 * [Practitioner Guide: Contributor Sustainability](https://chaoss.community/practitioner-guide-contributor-sustainability/)
+* [Practitioner Guide: Responsiveness](https://chaoss.community/practitioner-guide-responsiveness/)
 * [Practitioner Guide: Organizational Participation](https://chaoss.community/practitioner-guide-organizational-participation/)
 
 We also have more guides coming soon. You can see the work in progress guides, contribute to them, and propose new guides in the [Practitioner Guides](https://github.com/chaoss/wg-data-science/tree/main/practitioner-guides) section of the CHAOSS Data Science Working Group repository.


### PR DESCRIPTION
Moved the contributor guide above responsiveness on the website landing page, since it might make more sense to read that one first.

Added a link to the chaosscast episode to the responsiveness guide resources section.