### PR TITLE
Rename existing guides to be clear that they are "Getting Started" guides

### DIFF
--- a/practitioner-guides/README.md
+++ b/practitioner-guides/README.md
@@ -2,7 +2,9 @@
 
 **Read the [Practitioner Guides](https://chaoss.community/about-chaoss-practitioner-guides/)**
 
-Practitioner Guides are designed to be used by practitioners who may not be experts in data analysis or open source. The goal is to help people understand how to interpret the data about an open source project to develop insights that can help improve the project health of an open source project. 
+Practitioner Guides are designed to be used by practitioners. The goal is to help people understand how to interpret the data about an open source project to develop insights that can help improve the project health of an open source project. 
+
+The Getting Started series of guides is designed for people who may not be experts in data analysis or open source.
 
 ## Audience for the Guides
 
@@ -15,9 +17,11 @@ Note that while these guides are being developed within the Data Science WG, we 
 We welcome contributions! If you'd like to work on a guide or propose a new guide, you can browse the [Practitioner Guide issues](https://github.com/chaoss/wg-data-science/issues?q=is%3Aissue+is%3Aopen+label%3A%22practitioner+guide%22) in the data science WG repo. We have some issues for guides that we know we want, but that have no yet been started, and you can create a new issue using our template to propose a new Practitioner Guide.
 
 A few things to keep in mind when contributing to these guides:
-* We have a Google Docs [template](https://docs.google.com/document/d/1xe3KkkoBHcn9tyFaMTQ0TIfzZGkJPzBvrravp8Cdtl4/edit?usp=sharing) that you should use when creating a new guide to make it easier for others to review and collaborate with you. We prefer for this document to be owned by the chaossproject@gmail.com account. You should link to your document from the GitHub issue.
+* We have Google Docs templates that you should use when creating a new guide to make it easier for others to review and collaborate with you. We prefer for this document to be owned by the chaossproject@gmail.com account. You should link to your document from the GitHub issue.
+  * [Getting Started Template](https://docs.google.com/document/d/1xe3KkkoBHcn9tyFaMTQ0TIfzZGkJPzBvrravp8Cdtl4/edit?usp=sharing)
+  * [Template for more advanced guides](https://docs.google.com/document/d/1GLPUdjWA6rz1chFl0psKmtb8uniDeuGyg9UWTDgjIAI/edit?usp=sharing)
+* Each Getting Started Practitioner Guide should contain no more than 4 metrics. Pick the 2-4 metrics that best represent the breadth of the topic and list additional metrics in Step 3. Advanced guides have no limit for the number of metrics.
 * Make sure that all links to metrics and metrics models use the permanent, non-changing link in the form of `https://chaoss.community/?p=####`. These links can be found near the end of every published metric.
-* Each Practitioner Guide should contain no more than 4 metrics. Pick the 2-4 metrics that best represent the breadth of the topic and list additional metrics in Step 3. 
 * Please read the [Practitioner Guide: Introduction](introduction.md) before starting and link to it rather than duplicating where possible. Note that some duplication is likely required for clarity in the individual guides.
-* To see an example of how this template looks when completed, see the [Responsiveness](https://docs.google.com/document/d/1bRe7m-kIr208H_MaubbU87QIJZJ18wc_g0mN_cEXO_c/edit) Guide.
+* To see an example of how this template looks when completed, see the [Published Guides](https://chaoss.community/about-chaoss-practitioner-guides/).
 

--- a/practitioner-guides/contributor-sustainability.md
+++ b/practitioner-guides/contributor-sustainability.md
@@ -1,4 +1,4 @@
-# Practitioner Guide: Contributor Sustainability
+# Practitioner Guide: Getting Started with Contributor Sustainability
 
 Primary metrics:
 * [Contributor Absence Factor](https://chaoss.community/?p=3944)

--- a/practitioner-guides/organizational-participation.md
+++ b/practitioner-guides/organizational-participation.md
@@ -1,4 +1,4 @@
-# Practitioner Guide: Organizational Participation
+# Practitioner Guide: Getting Started with Organizational Participation
 
 Primary metrics:
 

--- a/practitioner-guides/responsiveness.md
+++ b/practitioner-guides/responsiveness.md
@@ -1,4 +1,4 @@
-# Practitioner Guide: Responsiveness
+# Practitioner Guide: Getting Started with Responsiveness
 
 Primary metrics:
 * [Time to First Response](https://chaoss.community/?p=3448)

--- a/practitioner-guides/security.md
+++ b/practitioner-guides/security.md
@@ -1,4 +1,4 @@
-# Practitioner Guide: Security
+# Practitioner Guide: Getting Started with Security
 
 Primary metrics:
 

--- a/practitioner-guides/website-landing.md
+++ b/practitioner-guides/website-landing.md
@@ -1,14 +1,16 @@
-Practitioner Guides are designed to be used by practitioners who may not be experts in data analysis or open source. The goal is to help you understand how to interpret the data about an open source project to develop insights that can help you improve the project health of an open source project. 
+Practitioner Guides are designed to be used by practitioners. The goal is to help you understand how to interpret the data about an open source project to develop insights that can help you improve the project health of an open source project. 
+
+The Getting Started series of guides is designed for people who may not be experts in data analysis or open source.
 
 These guides will be especially useful for Open Source Program Offices (OSPOs), project leads, community managers, maintainers, and anyone who wants to better understand project health and take action on what they learn from their metrics.
 
 **Guides**
 
 * [Practitioner Guide: Introduction - Things to Think about When Interpreting Metrics](https://chaoss.community/practitioner-guide-introduction/) <- Please start here
-* [Practitioner Guide: Contributor Sustainability](https://chaoss.community/practitioner-guide-contributor-sustainability/)
-* [Practitioner Guide: Responsiveness](https://chaoss.community/practitioner-guide-responsiveness/)
-* [Practitioner Guide: Organizational Participation](https://chaoss.community/practitioner-guide-organizational-participation/)
-* [Practitioner Guide: Security](https://chaoss.community/practitioner-guide-security/)
+* [Practitioner Guide: Getting Started with Contributor Sustainability](https://chaoss.community/practitioner-guide-contributor-sustainability/)
+* [Practitioner Guide: Getting Started with Responsiveness](https://chaoss.community/practitioner-guide-responsiveness/)
+* [Practitioner Guide: Getting Started with Organizational Participation](https://chaoss.community/practitioner-guide-organizational-participation/)
+* [Practitioner Guide: Getting Started with Security](https://chaoss.community/practitioner-guide-security/)
 
 A short video about each guide can be found in the [Practitioner Guides Playlist](https://www.youtube.com/playlist?list=PL60k37cxI-HSHV4-rEsWMzExw2y2Oq79Z) in the CHAOSS YouTube channel.
 


### PR DESCRIPTION
Slight rebranding to make it clear that the existing practitioner guides are Getting Started guides, since we are also working on some more advanced guides that will use a different template.