### PR TITLE
Moved hackathon details to point to website.

### DIFF
--- a/events/hackathon-june-2025.md
+++ b/events/hackathon-june-2025.md
@@ -1,18 +1,8 @@
 # CHAOSS Data Science Hackathon June 2025:
 
-**Note: The details are still a work in progress.**
-
 ## Logistics
 Date: June 26, 2025 
-Time: Morning (times TBD)
-Location: Denver TDB
 
 This event will be co-located with the [Open Source Summit North America](https://events.linuxfoundation.org/open-source-summit-north-america/) and will be held the morning before [CHAOSScon](https://chaoss.community/chaosscon-2025-na/)
 
-## Overview
-
-The [CHAOSS Data Science Working Group](https://github.com/chaoss/wg-data-science) is a community of folks collaborating on data science projects and how to guides within the CHAOSS project. We welcome data scientists, data analysts, researchers, and others with an interest in data. The goal of this hackathon is to drive interest in CHAOSS data science projects while making progress on one of more of our projects. The projects will be selected based on which members of the community plan to attend and are available to help lead people through the work. We plan to have a variety of activities so that everyone will have something to contribute whether they are new to data science or an experienced professional. This will likely include everything from data gathering and analysis to writing up results of our research.
-
-## Agenda
-
-TBD
+The details and registration for this event can now be found on the [CHAOSS Website](https://chaoss.community/chaoss-data-science-hackathon-2025/)


### PR DESCRIPTION
Removed details from this page and added a link to where it now exists on the CHAOSS website to avoid duplication and make it easier for people to find the registration