### PR TITLE
adding tracker for apache data collection and 2 sample apache project data

### DIFF
--- a/dataset/foundational-stats-research/README.md
+++ b/dataset/foundational-stats-research/README.md
@@ -3,6 +3,12 @@
 
 This project is part of the [CHAOSS Data Science Working Group](https://chaoss.community/inside-the-chaoss-data-science-working-group/) initiative to develop rigorous, evidence-based statistical frameworks for understanding collaboration patterns across major open source foundations.
 
+## IMPORTANT INFO:
+We are currently focused on manualy collecting the Apache metadata from individual websites. If you'd like to contribute to this effort, kindly use [this tracker](https://docs.google.com/spreadsheets/d/1rWW773oOudiM5xpfroIjEiQazOr42YNCfGWISnR0Tk4/edit?usp=sharing) to know what project you can document:
+-  "In Progress" means a contributor has started working on the project but yet to send a PR or PR is yet to be merged.
+- "Done" implies that the metadata for that Apache project has been done and merged to /data/raw/apache.json
+- Empty or "To Do" means noone is currently working on the project. If you decide to work on it, please change the status to "In Progress" to avoid duplicating efforts from contributors. 
+
 ## 🎯 Project Overview
 
 This research project conducts a comprehensive, reproducible assessment of community health across three major open source ecosystems: **Cloud Native Computing Foundation (CNCF)**, **Apache Software Foundation**, and **Eclipse Foundation**. 

--- a/dataset/foundational-stats-research/data/raw/apache.json
+++ b/dataset/foundational-stats-research/data/raw/apache.json
@@ -1,0 +1,23 @@
+[
+    {
+      "project": "Apache Accumulo",
+      "slack_url": "https://the-asf.slack.com/",
+      "mailing_list": "https://accumulo.apache.org/contact-us/#mailing-lists",
+      "discord_url": null,
+      "zulip_url": null,
+      "forum_url": null,
+      "blog_url": null,
+      "docs_url": "https://accumulo.apache.org/docs/2.x/getting-started/quickstart"
+    },
+    {
+      "project": "Apache Fluo",
+      "slack_url": "https://the-asf.slack.com/",
+      "mailing_list": "https://fluo.apache.org/contactus/",
+      "discord_url": null,
+      "zulip_url": null,
+      "forum_url": null,
+      "docs_url": "https://fluo.apache.org//docs/fluo/1.2/getting-started/design",
+      "blog_url": null
+    },
+
+]


### PR DESCRIPTION
This PR majorly :

 - Updates the Readme with an "IMPORTANT INFO" at the top for potential new contributor with a tracker (Google sheet). It contains the respective name, url and status (To-do, In progress, Done). Hopefully, this could help avoid duplicating efforts.
 - Also, the 2 sample projects we worked on during the focus group call we had last week is documented in /data/raw/apache.json.
 
 Happy to hear our reviews.
 
  