### PR TITLE
Add manually validated communication metadata for 7 Apache projects

### DIFF
--- a/dataset/foundational-stats-research/data/raw/apache.json
+++ b/dataset/foundational-stats-research/data/raw/apache.json
@@ -87,7 +87,7 @@
       "zulip_url": null,
       "forum_url": null,
       "docs_url": "https://tika.apache.org/3.2.3/index.html",
-      "blog_url": "https://tika.apache.org/"
+      "blog_url": null
     },
     {"project": "Apache Fluo Recipes",
      "slack_url": "https://the-asf.slack.com/",


### PR DESCRIPTION
## Summary
This PR adds manually validated communication and documentation metadata for **7 Apache projects**, following the schema and folder structure introduced in #173.

The data was collected directly from official Apache project websites and community pages, using only publicly listed links.

## Projects covered
- Apache Arrow  
- Apache Atlas  
- Apache Avro  
- Apache Beam  
- Apache BookKeeper  
- Apache Calcite  
- Apache Tika  

Fields with no publicly listed links were explicitly set to `null`.

## Related Issue 
Contributes to #152